### PR TITLE
fix(footer): update copyright year to be dynamic

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -12,7 +12,7 @@ export default function Footer() {
         </div>
         <div className="mt-12 pt-8 border-t border-gray-100 text-center">
           <p className="text-gray-500 font-light text-sm">
-            © 2024 Buntega Kollektiv. All rights reserved.
+            © {new Date().getFullYear().toString()} Buntega Kollektiv. All rights reserved.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Update the footer to display the current year dynamically instead of a static value.